### PR TITLE
Rewrite handlePaste method to handle sanitizing in a contained div

### DIFF
--- a/vendor/assets/javascripts/mercury/page_editor.js.coffee
+++ b/vendor/assets/javascripts/mercury/page_editor.js.coffee
@@ -81,6 +81,7 @@ class @Mercury.PageEditor
 
   finalizeInterface: ->
     @snippetToolbar = new Mercury.SnippetToolbar(@document)
+    jQuery('<div>', { id: 'mercury-sanitizer', contenteditable: 'true', style: 'position:absolute;top:-1000px;left:-1000px;opacity:0;' }).appendTo(@document.find('body'))
 
     @hijackLinksAndForms()
     Mercury.trigger('mode', {mode: 'preview'}) unless @options.visible

--- a/vendor/assets/javascripts/mercury/regions/editable.js.coffee
+++ b/vendor/assets/javascripts/mercury/regions/editable.js.coffee
@@ -107,9 +107,7 @@ class @Mercury.Regions.Editable extends Mercury.Region
         return
       return if @pasting
       Mercury.changes = true
-      content = @element.html().replace(/^\s+|\s+$/g, '')
-      clearTimeout(@handlePasteTimeout)
-      @handlePasteTimeout = setTimeout((=> @handlePaste(content)), 400)
+      @handlePaste()
 
     @element.focus =>
       return if @previewing
@@ -324,39 +322,35 @@ class @Mercury.Regions.Editable extends Mercury.Region
     return element
 
 
-  handlePaste: (prePasteContent) ->
-    @pasting = true
-    prePasteContent = prePasteContent.replace(/^\<br\>/, '')
+  handlePaste: ->
+    if Mercury.config.cleanStylesOnPaste
+      # get current selection & range
+      selection = @selection()
+      selection.placeMarker()
 
-    # remove any regions that might have been pasted
-    @element.find('.mercury-region').remove()
+      sanitizer = jQuery(@document).find('#mercury-sanitizer')
 
-    # handle pasting from ms office etc
-    content = @content()
-    if content.indexOf('<!--StartFragment-->') > -1 || content.indexOf('="mso-') > -1 || content.indexOf('<o:') > -1 || content.indexOf('="Mso') > -1
-      # clean out all the tags from the pasted contents
-      cleaned = prePasteContent.singleDiff(@content()).sanitizeHTML()
-      try
-        # try to undo and put the cleaned html where the selection was
-        @document.execCommand('undo', false, null)
-        @execCommand('insertHTML', {value: cleaned})
-      catch error
-        # remove the pasted html and load up the cleaned contents into a modal
-        @content(prePasteContent)
-        Mercury.modal '/mercury/modals/sanitizer', {
-          title: 'HTML Sanitizer (Starring Clippy)',
-          afterLoad: -> @element.find('textarea').val(cleaned.replace(/<br\/>/g, '\n'))
-        }
-    else if Mercury.config.cleanStylesOnPaste
-      # strip styles
-      pasted = prePasteContent.singleDiff(@content())
+      sanitizer.bind 'focus', =>
 
-      container = jQuery('<div>').appendTo(@document.createDocumentFragment()).html(pasted)
-      container.find('[style]').attr({style: null})
+        # set 1ms timeout to allow paste event to complete
+        setTimeout(=>
+          # sanitize the pasted html
+          sanitizer.find('[style]').attr({style: null})
+          sanitizer.find('[class]').attr({class: null})
+          sanitizer.find('[id]').attr({id: null})
+          sanitizer.find('.mercury-region').remove()
 
-      @document.execCommand('undo', false, null)
-      @execCommand('insertHTML', {value: container.html()})
-    @pasting = false
+          # move cursor back to original element & position
+          selection.selectMarker(@element)
+          selection.removeMarker()
+
+          # paste sanitized content
+          @execCommand('insertHTML', {value: sanitizer.html()})
+          sanitizer.html('')
+
+        , 1)
+
+      sanitizer.html('').focus()
 
 
   # Custom actions (eg. things that execCommand doesn't do, or doesn't do well)


### PR DESCRIPTION
Here's a quick pull request to begin fixing the paste sanitizing. I am by no means a great javascript programmer but it's just here for you guys to take apart and implement it in a more elegant way.

This solves the problems with diff'ing the original content with the new content in order to find the pasted content and sanitize that. Also see issue #23.
