### PR TITLE
Allow custom dataType on page save

### DIFF
--- a/vendor/assets/javascripts/mercury/page_editor.js.coffee
+++ b/vendor/assets/javascripts/mercury/page_editor.js.coffee
@@ -2,6 +2,7 @@ class @Mercury.PageEditor
 
   # options
   # saveStyle: 'form', or 'json' (defaults to json)
+  # saveDataType: 'xml', 'json', 'jsonp', 'script', 'text', 'html' (defaults to json)
   # saveMethod: 'POST', or 'PUT', create or update actions on save (defaults to POST)
   # visible: boolean, if the interface should start visible or not (defaults to true)
   constructor: (@saveUrl = null, @options = {}) ->
@@ -169,7 +170,7 @@ class @Mercury.PageEditor
     method = 'PUT' if @options.saveMethod == 'PUT'
     jQuery.ajax url, {
       type: method || 'POST'
-      dataType: 'json'
+      dataType: @options.saveDataType || 'json'
       headers: @saveHeaders()
       data: {content: data, _method: method}
       success: =>


### PR DESCRIPTION
This allows you to set the dataType that is expected to be returned by the server when saving a page.

This can be helpful when you want the server to return some custom javascript action instead of a json value. If we do not set the dataType value to `script` instead of `json`, the jQuery.ajax event will fire `error` instead of `success`, resulting in a Mercury alert that the page couldn't be saved (which is false).

We could leave this value empty and let jQuery guess the kind of response (which it does quite well), but Rails actually uses the value to set the type of request being sent. Also, 

You can read more about this at http://api.jquery.com/jQuery.ajax/#jQuery-ajax-settings
