### PR TITLE
Fix user-defined PageEditor options

### DIFF
--- a/vendor/assets/javascripts/mercury_loader.js
+++ b/vendor/assets/javascripts/mercury_loader.js
@@ -137,7 +137,7 @@ if (!window.mercuryPackages) window.mercuryPackages = {
               document.body.style.visibility = 'visible';
               document.body.style.display = 'block';
               // Instantiate the PageEditor, passing in the options that were provided to the loader.
-              new Mercury.PageEditor(null, {visible: true});
+              new Mercury.PageEditor(null, options);
               // If there's a mercuryLoaded function available, call it.   You can provide one before the loading script
               // and it will be called after everything is loaded, but before everything is initialized.  You can bind
               // to the mercury:ready event or use Mercury.bind('ready', function() {}).


### PR DESCRIPTION
The user defined options aren't passed into Mercury.pageEditor when using `mercury_loader.js` to load Mercury, so the default options are always used instead. This fixes #36.
