### PR TITLE
Override default foreColor execCommand

### DIFF
--- a/vendor/assets/javascripts/mercury/regions/editable.js.coffee
+++ b/vendor/assets/javascripts/mercury/regions/editable.js.coffee
@@ -388,6 +388,8 @@ class @Mercury.Regions.Editable extends Mercury.Region
 
     removeFormatting: (selection) -> selection.insertTextNode(selection.textContent())
 
+    foreColor: (selection, options) -> selection.wrap("<span style=\"color:#{options.value.toHex()}\">", true)
+
     backColor: (selection, options) -> selection.wrap("<span style=\"background-color:#{options.value.toHex()}\">", true)
 
     overline: (selection) -> selection.wrap('<span style="text-decoration:overline">', true)


### PR DESCRIPTION
Safari (on OS X) uses

``` html
<font class="Apple-style-span" color="#ffcc33"></font>
```

when using the default foreColor execCommand, which isn't HTML5 compliant and injects ugly browser-specific classes. Instead use the more clean

``` html
<span style="color:#FFCC33"></span>
```
