### PR TITLE
Move routes into config/engine.rb

### DIFF
--- a/config/engine.rb
+++ b/config/engine.rb
@@ -2,5 +2,27 @@ require "rails"
 
 module Mercury
   class Engine < Rails::Engine
+    
+    # To load the routes for this Engine, within your main apps routes.rb file include
+    # the following:
+    #
+    #   Mercury::Engine.routes
+    def self.routes
+      Rails.application.routes.draw do
+
+        resources :images
+
+        match '/editor(/*requested_uri)' => "mercury#edit", :as => :mercury_editor
+        scope '/mercury' do
+          match ':type/:resource' => "mercury#resource"
+          match 'snippets/:name/options' => "mercury#snippet_options"
+          match 'snippets/:name/preview' => "mercury#snippet_preview"
+        end
+
+        if defined?(Mercury::Application)
+          match 'mercury/test_page' => "mercury#test_page"
+        end
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,1 @@
-Rails.application.routes.draw do
 
-  resources :images
-
-  match '/editor(/*requested_uri)' => "mercury#edit", :as => :mercury_editor
-  scope '/mercury' do
-    match ':type/:resource' => "mercury#resource"
-    match 'snippets/:name/options' => "mercury#snippet_options"
-    match 'snippets/:name/preview' => "mercury#snippet_preview"
-  end
-
-  if defined?(Mercury::Application)
-    match 'mercury/test_page' => "mercury#test_page"
-  end
-end


### PR DESCRIPTION
Move routes into config/engine.rb to prevent them from being automatically loaded in the host application.

Engine routes are loaded after the host app routes, which means the
host app routes could actually prevent Mercury's routes from working.
Also, if you don't intend to use Mercury features, such as the images
resources, you may not want them cluttering your host apps routes. By
moving the routes into config/engine.rb, they can explicitly loaded
anywhere in the host app's routes.rb, or not at all if you chose to
implement your own custom Mercury routes.
