### PR TITLE
Pass CSRF header through on snippet AJAX requests.

### DIFF
--- a/vendor/assets/javascripts/mercury/modal.js.coffee
+++ b/vendor/assets/javascripts/mercury/modal.js.coffee
@@ -135,6 +135,7 @@ jQuery.extend Mercury.modal, {
     else
       jQuery.ajax @url, {
         type: @options.loadType || 'get'
+        headers: @options.loadHeaders
         data: @options.loadData
         success: (data) => @loadContent(data)
         error: =>

--- a/vendor/assets/javascripts/mercury/snippet.js.coffee
+++ b/vendor/assets/javascripts/mercury/snippet.js.coffee
@@ -53,6 +53,7 @@ class @Mercury.Snippet
   loadPreview: (element, callback = null) ->
     jQuery.ajax Mercury.config.snippets.previewUrl.replace(':name', @name), {
       type: Mercury.config.snippets.method
+      headers: @saveHeaders()
       data: @options
       success: (data) =>
         @data = data
@@ -63,12 +64,19 @@ class @Mercury.Snippet
     }
 
 
+  saveHeaders: ->
+    headers = {}
+    headers[Mercury.config.csrfHeader] = Mercury.csrfToken
+    return headers
+
+
   displayOptions: ->
     Mercury.snippet = @
     Mercury.modal Mercury.config.snippets.optionsUrl.replace(':name', @name), {
       title: 'Snippet Options',
       handler: 'insertSnippet',
       loadType: Mercury.config.snippets.method,
+      loadHeaders: @saveHeaders(),
       loadData: @options
     }
 


### PR DESCRIPTION
Rails will throw a 'Can't verify CSRF token authenticity' warning and
expire the session is the CSRF token is not included in the AJAX
requests performed with interacting with snippets.
