### PR TITLE
Allow iframeSrc to be configured

### DIFF
--- a/vendor/assets/javascripts/mercury/page_editor.js.coffee
+++ b/vendor/assets/javascripts/mercury/page_editor.js.coffee
@@ -1,6 +1,7 @@
 class @Mercury.PageEditor
 
   # options
+  # iframeSrc: URL of page to load into editor iframe (defaults to current URL with path prefix "/editor" removed)
   # saveStyle: 'form', or 'json' (defaults to json)
   # saveDataType: 'xml', 'json', 'jsonp', 'script', 'text', 'html' (defaults to json)
   # saveMethod: 'POST', or 'PUT', create or update actions on save (defaults to POST)
@@ -150,7 +151,10 @@ class @Mercury.PageEditor
 
 
   iframeSrc: (url = null) ->
-    (url ? window.location.href).replace(/([http|https]:\/\/.[^\/]*)\/editor\/?(.*)/i, "$1/$2")
+    if @options.iframeSrc?
+      @options.iframeSrc
+    else
+      (url ? window.location.href).replace(/([http|https]:\/\/.[^\/]*)\/editor\/?(.*)/i, "$1/$2")
 
 
   hijackLinksAndForms: ->


### PR DESCRIPTION
This allows the `iframeSrc` to be configured. Feel free to change my approach if you don't like it. My motive is that I want to use Rails' default resourceful routes. 

show action: `/pages/<id>`
edit action : `/pages/<id>/edit`

The `edit` action renders the "mercury" layout and loads the `show` action into the iframe.

I'm blown away by the awesomeness of Mercury. Thanks!
