### PR TITLE
Allow the scope of a region to be specified via the 'data-scope' attribute.

### DIFF
--- a/vendor/assets/javascripts/mercury.js
+++ b/vendor/assets/javascripts/mercury.js
@@ -372,6 +372,16 @@ window.Mercury = {
     regionClass: 'mercury-region',
 
     
+    // ## Region Data Attributes
+    //
+    // These attributes, when applied to a Mercury region element, will be automatically serialized and submitted
+    // with the AJAX request sent when a page is saved. These are expected to be HTML5 data attributes, and 'data-'
+    // will automatically be prepended to each attribute listed here.
+    //
+    // Example: regionDataAttributes: ['scope', 'version']
+    regionDataAttributes: [],
+    
+    
     // ## Styles
     //
     // Mercury tries to stay as much out of your code as possible, but because regions appear within your document we

--- a/vendor/assets/javascripts/mercury/region.js.coffee
+++ b/vendor/assets/javascripts/mercury/region.js.coffee
@@ -7,7 +7,7 @@ class @Mercury.Region
 
     @document = @window.document
     @name = @element.attr('id')
-    @scope = @element.attr('data-scope')
+    @collectDataAttributes()
     @history = new Mercury.HistoryBuffer()
     @build()
     @bindEvents()
@@ -20,6 +20,11 @@ class @Mercury.Region
 
   focus: ->
 
+
+  collectDataAttributes: ->
+    @data = {}
+    $(Mercury.config.regionDataAttributes).each (index, item) =>
+      @data[item] = @element.attr('data-' + item)
 
   bindEvents: ->
     Mercury.on 'mode', (event, options) => @togglePreview() if options.mode == 'preview'
@@ -96,7 +101,7 @@ class @Mercury.Region
   serialize: ->
     return {
       type: @type
-      scope: @scope
+      data: @data
       value: @content(null, true)
       snippets: @snippets()
     }


### PR DESCRIPTION
Within the context of a site, a content region within a page could belong specifically to the page or globally to the site. A global/site content region would be shared with multiple pages within the site.

For example, given the following content regions on a page:

``` html
<div id="region_1" class="mercury-region" data-type="editable" data-scope="site"></div>
<div id="region_2" class="mercury-region" data-type="editable" data-scope="page"></div>
```

Editing the content in region_1 will affect all pages that include region_1, since it has been denoted as a 'site' region via the 'data-scope' attribute. Editing the content in region_2 will only affect the page that is being edited. The 'site' and 'page' scopes used here are just examples. The host application would define and handle the scopes it supports.
