### PR TITLE
Fix passing of boolean values as options to the mercury loader

### DIFF
--- a/vendor/assets/javascripts/mercury_loader.js
+++ b/vendor/assets/javascripts/mercury_loader.js
@@ -99,6 +99,7 @@ if (!window.mercuryPackages) window.mercuryPackages = {
         if (!match || !match[1]) continue;
 
         match[1].replace(/([^&=]*)=([^&=]*)/g, function (m, attr, value) {
+          if (['true', 'false'].indexOf(value) >= 0) value = JSON.parse(value);
           options[attr] = value;
         });
       }


### PR DESCRIPTION
I had to implement this fix to handle boolean values as option to the mercury loader. I discovered this bug while trying to pass ?visible=false to the mercury loader. The option was handled as a string and therefore the condition to check whether to make the editor visible or not was evaluated incorrectly.
