### PR TITLE
Made RegEx used to extract iFrameSrc configurable so that custom routes can be used.

### DIFF
--- a/spec/javascripts/mercury/page_editor_spec.js.coffee
+++ b/spec/javascripts/mercury/page_editor_spec.js.coffee
@@ -530,6 +530,12 @@ describe "Mercury.PageEditor", ->
     it "takes the location and removes the /editor", ->
       expect(@pageEditor.iframeSrc('http://foo.com/editor/path')).toEqual('http://foo.com/path')
 
+    it "uses the configured url regex to remove the editor", ->
+      original = Mercury.editorUrlRegEx
+      Mercury.editorUrlRegEx = /([http|https]:\/\/[^\/]*)\/(.*)\/edit\/?/i
+      expect(@pageEditor.iframeSrc('http://foo.com/path/edit')).toEqual('http://foo.com/path')
+      Mercury.editorUrlRegEx = original
+
     it "adds query params", ->
       expect(@pageEditor.iframeSrc('http://foo.com/editor/path', true)).toEqual('http://foo.com/path?mercury_frame=true')
       expect(@pageEditor.iframeSrc('http://foo.com/editor/path?something=true', true)).toEqual('http://foo.com/path?something=true&mercury_frame=true')

--- a/vendor/assets/javascripts/mercury.js
+++ b/vendor/assets/javascripts/mercury.js
@@ -465,6 +465,8 @@ window.Mercury = {
   // place to add or change functionality.
   onload: function() {
     //Mercury.PageEditor.prototype.iframeSrc = function(url) { return '/testing'; }
-  }
+  },
+
+  editorUrlRegEx: /([http|https]:\/\/.[^\/]*)\/editor\/?(.*)/i
 
 };

--- a/vendor/assets/javascripts/mercury/page_editor.js.coffee
+++ b/vendor/assets/javascripts/mercury/page_editor.js.coffee
@@ -162,7 +162,7 @@ class @Mercury.PageEditor
 
 
   iframeSrc: (url = null, params = false) ->
-    url = (url ? window.location.href).replace(/([http|https]:\/\/.[^\/]*)\/editor\/?(.*)/i, "$1/$2")
+    url = (url ? window.location.href).replace(Mercury.editorUrlRegEx ?= /([http|https]:\/\/.[^\/]*)\/editor\/?(.*)/i,  "$1/$2")
     url = url.replace(/[\?|\&]mercury_frame=true/gi, '')
     if params
       return "#{url}#{if url.indexOf('?') > -1 then '&' else '?'}mercury_frame=true"


### PR DESCRIPTION
Added "editorUrlRegex" to Mercury configuration to override default http://example.com/editor/* route.
Added fallback to default route regex if no override is specified.

This change allows custom routes to be used for the Mercury controller. For example:

``` ruby

App.routes.draw do
   scope '/mercury' do
     match ':type/:resource' => "mercury#resource"
     match 'snippets/:name/options' => "mercury#snippet_options"
     match 'snippets/:name/preview' => "mercury#snippet_preview"
   end

   # This route can be used by configuring Mercury to use the following regex: /([http|https]:\/\/[^\/]*)\/(.*)\/edit\/?/i
   match '*path/edit' => "mercury#edit", :as => :mercury_editor
end

```

This commit resolves an issue of infinite recursive loading of the editor when using a route different from Mercury's default route.
