### PR TITLE
Layout and config

### DIFF
--- a/app/views/layouts/mercury.html.erb
+++ b/app/views/layouts/mercury.html.erb
@@ -5,10 +5,11 @@
     <%= csrf_meta_tags %>
     <title>Mercury Editor</title>
     <%= stylesheet_link_tag    'mercury', 'mercury_overrides' %>
-    <%= javascript_include_tag 'mercury' %>
+    <%= javascript_include_tag 'mercury', 'mercury_overrides' %>
   </head>
   <body>
     <script type="text/javascript">
+
       <% if Rails.application.config.respond_to?(:mercury_config) %>
         jQuery.extend(Mercury.config, <%= Rails.application.config.mercury_config.to_json.html_safe %>);
       <% end -%>

--- a/vendor/assets/javascripts/mercury_overrides.js
+++ b/vendor/assets/javascripts/mercury_overrides.js
@@ -1,0 +1,6 @@
+/*!
+ * Mercury Editor is a Coffeescript and jQuery based WYSIWYG editor.  Documentation and other useful information can be
+ * found at https://github.com/jejacks0n/mercury
+ *
+ * This file is intended to provide a standard way to override or add JS that comes default with Mercury Editor.
+ */


### PR DESCRIPTION
I'd like to leave the default layout alone, but gain the ability to override editor options.
1. In the vain of Rails.application.config.mercury_config, support mercury_page_editor_config.
2. Would seem that template should convert a ruby hash to_json. Might affect existing installations using mercury_config. Thoughts?
