### PR TITLE
Add determineType for programatically deciding what type a region is

### DIFF
--- a/vendor/assets/javascripts/mercury.js
+++ b/vendor/assets/javascripts/mercury.js
@@ -230,6 +230,9 @@ window.Mercury = {
     // By default this is the id attribute but can be changed to a data attribute should you want to use something
     // custom instead.
     //
+    // determineType: This function is called after checking the data-type attribute for the correct field type. Use
+    // it if you want to programatically set the type based on inspection of the region.
+    //
     // dataAttributes: The dataAttributes is an array of data attributes that will be serialized and returned to the
     // server upon saving.  These attributes, when applied to a Mercury region element, will be automatically serialized
     // and submitted with the AJAX request sent when a page is saved.  These are expected to be HTML5 data attributes,
@@ -237,6 +240,7 @@ window.Mercury = {
     regions: {
       className: 'mercury-region',
       identifier: 'id',
+      // determineType: function(region){},
       dataAttributes: []
       },
 

--- a/vendor/assets/javascripts/mercury/page_editor.js.coffee
+++ b/vendor/assets/javascripts/mercury/page_editor.js.coffee
@@ -75,7 +75,11 @@ class @Mercury.PageEditor
     if region.data('region')
       region = region.data('region')
     else
-      type = (region.data('type') || 'unknown').titleize()
+      type = (
+        region.data('type') ||
+        ( jQuery.type(Mercury.config.regions.determineType) == 'function' && Mercury.config.regions.determineType(region) ) ||
+        'unknown'
+      ).titleize()
       throw Mercury.I18n('Region type is malformed, no data-type provided, or "%s" is unknown for the "%s" region.', type, region.attr('id') || 'unknown') if type == 'Unknown' || !Mercury.Regions[type]
       if !Mercury.Regions[type].supported
         Mercury.notify('Mercury.Regions.%s is unsupported in this client. Supported browsers are %s.', type, Mercury.Regions[type].supportedText)


### PR DESCRIPTION
This adds an option for deciding what regions are what type. For instance, I'm using it to set all divs to editable and some other tags to a 'simple' type. A hard-coded `data-type` attribute on the DOM still has precedence.

Example:

``` javascript
determineType: function(region){
  if (region.get(0).tagName == 'DIV')
    return 'editable';
  else if (region.get(0).tagName.match(/(H[1-5]|LI|SPAN|STRONG|EM|B|I|TD)/))
    return 'simple';
  else
    return false;
},
```
