### PR TITLE
set_table_name has been deprecated in favor of self.table_name= as of Rails 3.2 (commit 0b72a04)

### DIFF
--- a/app/models/mercury/image.rb
+++ b/app/models/mercury/image.rb
@@ -1,6 +1,6 @@
 class Mercury::Image < ActiveRecord::Base
 
-  set_table_name :mercury_images
+  self.table_name = :mercury_images
 
   has_attached_file :image, :styles => { :medium => "300x300>", :thumb => "100x100>" }
 


### PR DESCRIPTION
set_table_name has been deprecated in favor of self.table_table= in [0b72a04 commit](https://github.com/rails/rails/commit/0b72a04). I checked the code of AR::Base of Version 3.0 and table_name= was an alias for set_table_name so this change is safe on any version of Rails 3.
