### PR TITLE
Fixing bug where PageEditor doesn't check editorUrlRegEx in config correctly.

### DIFF
--- a/vendor/assets/javascripts/mercury/page_editor.js.coffee
+++ b/vendor/assets/javascripts/mercury/page_editor.js.coffee
@@ -162,7 +162,7 @@ class @Mercury.PageEditor
 
 
   iframeSrc: (url = null, params = false) ->
-    url = (url ? window.location.href).replace(Mercury.editorUrlRegEx ?= /([http|https]:\/\/.[^\/]*)\/editor\/?(.*)/i,  "$1/$2")
+    url = (url ? window.location.href).replace(Mercury.config.editorUrlRegEx ?= /([http|https]:\/\/.[^\/]*)\/editor\/?(.*)/i,  "$1/$2")
     url = url.replace(/[\?|\&]mercury_frame=true/gi, '')
     if params
       return "#{url}#{if url.indexOf('?') > -1 then '&' else '?'}mercury_frame=true"


### PR DESCRIPTION
Fixed bug in the check of Mercury.config.editorUrlRegex in PageEditor.
PageEditor was not picking up the changes in Mercury.config, and instead checking Mercury.editorUrlRegex.

This commit reads editorUrlRegex correctly and fixes recursion issue when using an editing route different from the Mercury default.
