### PR TITLE
Snippet identity name is now set correctly even when a snippet with same identity exists.

### DIFF
--- a/spec/javascripts/mercury/snippet_spec.js.coffee
+++ b/spec/javascripts/mercury/snippet_spec.js.coffee
@@ -218,7 +218,15 @@ describe "Mercury.Snippet class methods", ->
     it "pushes into the collection array", ->
       Mercury.Snippet.create('foo', {foo: 'bar'})
       expect(Mercury.Snippet.all.length).toEqual(1)
+      
+    describe "when an snuppet exist with an identical identity", ->
+      it "generates a unique identity", ->
+        Mercury.Snippet.load
+          snippet_1: {name: 'foo', options: {foo: 'bar'}}
+          snippet_2: {name: 'bar', options: {baz: 'pizza'}}
 
+        ret = Mercury.Snippet.create('noobie', {noobie: 'one'})
+        expect(ret.identity).toEqual('snippet_0')
 
   describe ".find", ->
 

--- a/vendor/assets/javascripts/mercury/snippet.js.coffee
+++ b/vendor/assets/javascripts/mercury/snippet.js.coffee
@@ -12,7 +12,13 @@ class @Mercury.Snippet
 
 
   @create: (name, options) ->
-    identity = "snippet_#{@all.length}"
+    if @all.length > 0
+      identity = "snippet_0"
+      for snippet, i in @all
+        identity = "snippet_#{i+1}" if snippet.identity == identity
+    else
+      identity = "snippet_#{@all.length}"
+    
     instance = new Mercury.Snippet(name, identity, options)
     @all.push(instance)
     return instance


### PR DESCRIPTION
When a page has existing snippets, creating a new snippet does not respect the identity of those existing snippets. Which can result in two or more snippets with the same identity. This pull request fixes that.
