### PR TITLE
Another small Sprockets dependency fix

### DIFF
--- a/mercury-rails.gemspec
+++ b/mercury-rails.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |s|
 
 
   # Development Dependencies
-  s.add_development_dependency('sprockets-helpers')
+  s.add_development_dependency('sprockets', '~> 2.1')
   s.add_development_dependency('rocco', '>= 0.8.2')
   s.add_development_dependency('uglifier')
-  s.add_development_dependency('jquery-rails')
+  s.add_development_dependency('jquery-rails', '~> 1.0')
   s.add_development_dependency('sqlite3')
   s.add_development_dependency('ruby-debug19')
   s.add_development_dependency('evergreen', '>= 1.0.0')


### PR DESCRIPTION
Heyyo. So my last sprockets requirements change actually busted the web server. These requirements just roll Mercury back and away from the latest Sprockets releases, which seem to behave badly with current Rails releases.
