### PR TITLE
Add a span element to the panel h1 to act as the draggable handle.

### DIFF
--- a/vendor/assets/javascripts/mercury/panel.js.coffee
+++ b/vendor/assets/javascripts/mercury/panel.js.coffee
@@ -6,7 +6,7 @@ class @Mercury.Panel extends Mercury.Dialog
 
   build: ->
     @element = jQuery('<div>', {class: 'mercury-panel loading', style: 'display:none;'})
-    @titleElement = jQuery("<h1>#{Mercury.I18n(@options.title)}</h1>").appendTo(@element)
+    @titleElement = jQuery("<h1><span>#{Mercury.I18n(@options.title)}<span></h1>").appendTo(@element)
     @paneElement = jQuery('<div>', {class: 'mercury-panel-pane'}).appendTo(@element)
 
     if @options.closeButton
@@ -100,7 +100,7 @@ class @Mercury.Panel extends Mercury.Dialog
   makeDraggable: ->
     elementWidth = @element.width()
     @element.draggable {
-      handle: 'h1',
+      handle: 'h1 span',
       axis: 'x',
       opacity: 0.70
       scroll: false,

--- a/vendor/assets/stylesheets/mercury/dialog.css
+++ b/vendor/assets/stylesheets/mercury/dialog.css
@@ -78,6 +78,10 @@
   cursor: move;
   text-shadow: 1px 1px 2px rgba(0,0,0, .9);
 }
+.mercury-panel h1 span {
+  display: block;
+  width: 100%;
+}
 .mercury-panel h1 a.mercury-panel-close {
   position: absolute;
   right: -5px;


### PR DESCRIPTION
In some situations, making the entire h1 the draggable handle prevents the close link from being clicked. By adding an span element to the h1 and making it the draggable handle, the close link remains clickable.
