### PR TITLE
Move form styles into their own file and namespace with .mercury-form.

### DIFF
--- a/app/views/mercury/modals/character.html
+++ b/app/views/mercury/modals/character.html
@@ -1,4 +1,4 @@
-<form id="mercury_character" style="width:456px">
+<form id="mercury_character" class="mercury-form" style="width:456px">
 
   <div class="mercury-display-pane-container">
     <div class="mercury-display-pane">

--- a/app/views/mercury/modals/htmleditor.html
+++ b/app/views/mercury/modals/htmleditor.html
@@ -1,4 +1,4 @@
-<form id="mercury_html_editor" style="width:650px">
+<form id="mercury_html_editor" class="mercury-form" style="width:650px">
 
   <textarea class="mercury-display-pane-container" rows="5" style="width:100%"></textarea>
 

--- a/app/views/mercury/modals/link.html
+++ b/app/views/mercury/modals/link.html
@@ -1,4 +1,4 @@
-<form id="mercury_link" style="width:600px">
+<form id="mercury_link" class="mercury-form" style="width:600px">
 
   <div class="mercury-display-pane-container">
     <div class="mercury-display-pane">

--- a/app/views/mercury/modals/media.html
+++ b/app/views/mercury/modals/media.html
@@ -1,4 +1,4 @@
-<form id="mercury_media" style="width:600px">
+<form id="mercury_media" class="mercury-form" style="width:600px">
 
   <div class="mercury-display-pane-container">
     <div class="mercury-display-pane">

--- a/app/views/mercury/modals/table.html
+++ b/app/views/mercury/modals/table.html
@@ -1,4 +1,4 @@
-<form id="mercury_table" style="width:700px">
+<form id="mercury_table" class="mercury-form" style="width:700px">
 
   <div class="mercury-display-pane-container">
     <div class="mercury-display-pane">

--- a/app/views/mercury/snippets/example/options.html.erb
+++ b/app/views/mercury/snippets/example/options.html.erb
@@ -1,4 +1,4 @@
-<%= form_for 'options', { :html => { :style => 'width:600px' } } do |f| %>
+<%= form_for 'options', { :html => { :class => 'mercury-form', :style => 'width:600px' } } do |f| %>
 
   <div class="mercury-display-pane-container">
     <div class="mercury-display-pane">

--- a/vendor/assets/stylesheets/mercury/form.css
+++ b/vendor/assets/stylesheets/mercury/form.css
@@ -1,0 +1,118 @@
+/*
+ * Forms
+ *---------------------------------------------------------------------------*/
+.mercury-form,
+.mercury-form ul,
+.mercury-form ol,
+.mercury-form li,
+.mercury-form fieldset,
+.mercury-form p {
+  margin: 0;
+  padding: 0;
+}
+.mercury-form abbr {
+  border: 0;
+  font-variant: normal;
+}
+.mercury-form fieldset {
+  margin-bottom: 10px;
+  background: #F6F6F6;
+  border: 1px solid #CCC;
+  border-radius: 7px;
+  -moz-border-radius: 7px;
+}
+.mercury-form fieldset:last-child {
+  margin-bottom: 0;
+}
+.mercury-form fieldset legend {
+  font-weight: bold;
+  margin-left: 10px;
+  margin-bottom: -4px;
+}
+.mercury-form ol {
+  margin: 12px 9px;
+}
+.mercury-form ol li {
+  display: block;
+  margin-bottom: 10px;
+}
+.mercury-form label {
+  display: block;
+  float: left;
+  width: 23%;
+  margin-right: 9px;
+  text-align: right;
+  line-height: 27px;
+  font-size: 1.1em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mercury-form label input {
+  width: auto !important;
+  margin: 0 5px 0 2px !important;
+}
+.mercury-form select,
+.mercury-form input[type=text],
+.mercury-form input[type=password],
+.mercury-form textarea,
+.mercury-form input.text {
+  margin: 0;
+  border: 2px solid #CCC;
+  padding: 2px 4px;
+  font-family: Arial, Geneva, sans-serif;
+  font-size: 1.5em;
+  width: 74%;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+}
+.mercury-form li.boolean {
+  margin-left: 23%;
+  padding-left: 9px;
+}
+.mercury-form li.boolean label {
+  width: auto;
+}
+.mercury-form fieldset.buttons {
+  clear: both;
+  padding: 0;
+  background: none;
+  border: none;
+  text-align: left;
+}
+.mercury-form fieldset.buttons ol {
+  margin: 0 -2px 0 0;
+  float: right;
+}
+.mercury-form fieldset.buttons ol li {
+  float: left;
+  padding-left: 0.5em;
+  padding-right: 0;
+}
+.mercury-form fieldset.buttons .commit {
+  margin: 0;
+}
+.mercury-form fieldset.buttons .commit input {
+  padding: 8px 14px 9px !important;
+  font-family: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', sans-serif;
+  font-size: 1.3em;
+  background-color: #222;
+  background-repeat: repeat-x;
+  display: inline-block;
+  color: #FFF;
+  text-decoration: none;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+  -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+  text-shadow: 0 -1px 1px rgba(0, 0, 0, 0.25);
+  border: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+  position: relative;
+  cursor: pointer;
+  line-height: normal;
+}
+.mercury-form fieldset.buttons .commit input:hover {
+  background-color: #000;
+}

--- a/vendor/assets/stylesheets/mercury/mercury.css
+++ b/vendor/assets/stylesheets/mercury/mercury.css
@@ -1,5 +1,6 @@
 /*
  *= require_self
+ *= require ./form
  *= require ./dialog
  *= require ./lightview
  *= require ./modal
@@ -30,122 +31,7 @@ html, body {
   opacity: 0;
 }
 
-/*
- * Forms
- *---------------------------------------------------------------------------*/
-form,
-form ul,
-form ol,
-form li,
-form fieldset,
-form p,
 .filter {
   margin: 0;
   padding: 0;
-}
-form abbr {
-  border: 0;
-  font-variant: normal;
-}
-form fieldset {
-  margin-bottom: 10px;
-  background: #F6F6F6;
-  border: 1px solid #CCC;
-  border-radius: 7px;
-  -moz-border-radius: 7px;
-}
-form fieldset:last-child {
-  margin-bottom: 0;
-}
-form fieldset legend {
-  font-weight: bold;
-  margin-left: 10px;
-  margin-bottom: -4px;
-}
-form ol {
-  margin: 12px 9px;
-}
-form ol li {
-  display: block;
-  margin-bottom: 10px;
-}
-form label {
-  display: block;
-  float: left;
-  width: 23%;
-  margin-right: 9px;
-  text-align: right;
-  line-height: 27px;
-  font-size: 1.1em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-form label input {
-  width: auto !important;
-  margin: 0 5px 0 2px !important;
-}
-form select,
-form input[type=text],
-form input[type=password],
-form textarea,
-form input.text {
-  margin: 0;
-  border: 2px solid #CCC;
-  padding: 2px 4px;
-  font-family: Arial, Geneva, sans-serif;
-  font-size: 1.5em;
-  width: 74%;
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-}
-form li.boolean {
-  margin-left: 23%;
-  padding-left: 9px;
-}
-form li.boolean label {
-  width: auto;
-}
-form fieldset.buttons {
-  clear: both;
-  padding: 0;
-  background: none;
-  border: none;
-  text-align: left;
-}
-form fieldset.buttons ol {
-  margin: 0 -2px 0 0;
-  float: right;
-}
-form fieldset.buttons ol li {
-  float: left;
-  padding-left: 0.5em;
-  padding-right: 0;
-}
-form fieldset.buttons .commit {
-  margin: 0;
-}
-form fieldset.buttons .commit input {
-  padding: 8px 14px 9px !important;
-  font-family: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', sans-serif;
-  font-size: 1.3em;
-  background-color: #222;
-  background-repeat: repeat-x;
-  display: inline-block;
-  color: #FFF;
-  text-decoration: none;
-  -moz-border-radius: 5px;
-  -webkit-border-radius: 5px;
-  -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
-  -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
-  text-shadow: 0 -1px 1px rgba(0, 0, 0, 0.25);
-  border: 0;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.25);
-  position: relative;
-  cursor: pointer;
-  line-height: normal;
-}
-form fieldset.buttons .commit input:hover {
-  background-color: #000;
 }


### PR DESCRIPTION
Related to issue #163.

This allows Twitter Bootstrap to be used alongside Mercury for modals, panels, etc. I've been using this for a couple weeks with good results and thought it may be useful to others. 

It simply namespaces the mercury form styles so that they do not collide with the Bootstrap form styles.
