### PR TITLE
Events when changing previewing mode or changes state

### DIFF
--- a/public/mercury/javascripts/mercury.js
+++ b/public/mercury/javascripts/mercury.js
@@ -13784,7 +13784,7 @@ Showdown.converter = function() {
           _method: method
         },
         success: function() {
-          Mercury.changes = false;
+          Mercury.trigger('set-changes', false);
           Mercury.trigger('saved');
           if (typeof callback === 'function') return callback();
         },
@@ -16311,7 +16311,7 @@ Showdown.converter = function() {
       this.focus();
       if (action !== 'redo') this.pushHistory();
       Mercury.log('execCommand', action, options.value);
-      if (!options.already_handled) return Mercury.changes = true;
+      if (!options.already_handled) return Mercury.trigger('set-changes', true);
     };
 
     Region.prototype.pushHistory = function() {
@@ -16784,7 +16784,7 @@ Showdown.converter = function() {
           return;
         }
         if (_this.pasting) return;
-        Mercury.changes = true;
+        Mercury.trigger('set-changes', true);
         return _this.handlePaste(event.originalEvent);
       });
       this.element.on('focus', function() {
@@ -16886,7 +16886,7 @@ Showdown.converter = function() {
         Mercury.trigger('region:update', {
           region: _this
         });
-        return Mercury.changes = true;
+        return Mercury.trigger('set-changes', true);
       });
     };
 
@@ -17688,7 +17688,7 @@ Showdown.converter = function() {
       });
       this.element.on('keyup', function() {
         if (_this.previewing) return;
-        Mercury.changes = true;
+        Mercury.trigger('set-changes', true);
         _this.resize();
         return Mercury.trigger('region:update', {
           region: _this
@@ -18192,7 +18192,7 @@ Showdown.converter = function() {
       });
       this.element.on('keyup', function() {
         if (_this.previewing) return;
-        Mercury.changes = true;
+        Mercury.trigger('set-changes', true);
         _this.resize();
         return Mercury.trigger('region:update', {
           region: _this
@@ -18212,7 +18212,7 @@ Showdown.converter = function() {
           return;
         }
         if (_this.pasting) return;
-        Mercury.changes = true;
+        Mercury.trigger('set-changes', true);
         return _this.handlePaste(event.originalEvent);
       });
     };
@@ -18510,7 +18510,7 @@ Showdown.converter = function() {
       });
       return jQuery(this.document).on('keyup', function() {
         if (_this.previewing || Mercury.region !== _this) return;
-        return Mercury.changes = true;
+        return Mercury.trigger('set-changes', true);
       });
     };
 

--- a/spec/javascripts/mercury/page_editor_spec.js.coffee
+++ b/spec/javascripts/mercury/page_editor_spec.js.coffee
@@ -592,12 +592,12 @@ describe "Mercury.PageEditor", ->
       Mercury.PageEditor.prototype.initializeInterface = ->
       @pageEditor = new Mercury.PageEditor('', {appendTo: $('#test')})
       Mercury.silent = false
-      Mercury.changes = true
+      Mercury.trigger('set-changes', true)
 
     it "returns a message if changes were made", ->
       expect(@pageEditor.beforeUnload()).toEqual('You have unsaved changes.  Are you sure you want to leave without saving them first?')
 
-      Mercury.changes = false
+      Mercury.trigger('set-changes', false)
       expect(@pageEditor.beforeUnload()).toEqual(null)
 
     it "does nothing if in silent mode", ->
@@ -692,7 +692,7 @@ describe "Mercury.PageEditor", ->
           @ajaxSpy.andCallFake((url, options) => options.success('data') )
 
         it "sets changes back to false", ->
-          Mercury.changes = true
+          Mercury.trigger('set-changes', true)
           @pageEditor.save()
           expect(Mercury.changes).toEqual(false)
 

--- a/spec/javascripts/mercury/region_spec.js.coffee
+++ b/spec/javascripts/mercury/region_spec.js.coffee
@@ -223,7 +223,7 @@ describe "Mercury.Region", ->
   describe "#execCommand", ->
 
     beforeEach ->
-      Mercury.changes = false
+      Mercury.trigger('set-changes', false)
       @region = new Mercury.Region($('#region'), window)
 
     it "calls focus", ->
@@ -246,7 +246,7 @@ describe "Mercury.Region", ->
   describe "#pushHistory", ->
 
     beforeEach ->
-      Mercury.changes = false
+      Mercury.trigger('set-changes', false)
       @region = new Mercury.Region($('#region'), window)
 
     it "pushes the current content (html) of the region to the history buffer", ->

--- a/vendor/assets/javascripts/mercury/page_editor.js.coffee
+++ b/vendor/assets/javascripts/mercury/page_editor.js.coffee
@@ -106,6 +106,7 @@ class @Mercury.PageEditor
     Mercury.on 'focus:window', => setTimeout(10, => @focusableElement.focus())
     Mercury.on 'toggle:interface', => @toggleInterface()
     Mercury.on 'toggle:preview', (event, data) => @togglePreview(data)
+    Mercury.on 'set-changes', (event, data) => @setChanges(data)
     Mercury.on 'reinitialize', => @initializeRegions()
     Mercury.on 'mode', (event, options) => Mercury.trigger('toggle:preview', !@previewing) if options.mode == 'preview'
     Mercury.on 'action', (event, options) =>
@@ -152,6 +153,11 @@ class @Mercury.PageEditor
 
   togglePreview: (previewing) ->
     @previewing = previewing
+
+  setChanges: (changes) ->
+    if Mercury.changes != changes
+      Mercury.changes = changes
+      Mercury.trigger('changes', changes)
 
   resize: ->
     width = jQuery(window).width()
@@ -213,7 +219,7 @@ class @Mercury.PageEditor
       dataType: @options.saveDataType,
       data: {content: data, _method: method}
       success: =>
-        Mercury.changes = false
+        Mercury.trigger('set-changes', false)
         Mercury.trigger('saved')
         callback() if typeof(callback) == 'function'
       error: (response) =>

--- a/vendor/assets/javascripts/mercury/plugins/save_as_xml/mercury/page_editor.js.coffee
+++ b/vendor/assets/javascripts/mercury/plugins/save_as_xml/mercury/page_editor.js.coffee
@@ -12,7 +12,7 @@ class Mercury.PageEditor extends Mercury.PageEditor
       dataType: 'xml'
       data: data
       success: =>
-        Mercury.changes = false
+        Mercury.trigger('set-changes', false)
       error: =>
         alert("Mercury was unable to save to the url: #{url}")
     }

--- a/vendor/assets/javascripts/mercury/region.js.coffee
+++ b/vendor/assets/javascripts/mercury/region.js.coffee
@@ -76,7 +76,7 @@ class @Mercury.Region
     @pushHistory() unless action == 'redo'
 
     Mercury.log('execCommand', action, options.value)
-    Mercury.changes = true unless options.already_handled
+    Mercury.trigger('set-changes', true) unless options.already_handled
 
 
   pushHistory: ->

--- a/vendor/assets/javascripts/mercury/regions/editable.js.coffee
+++ b/vendor/assets/javascripts/mercury/regions/editable.js.coffee
@@ -109,7 +109,7 @@ class @Mercury.Regions.Editable extends Mercury.Region
         event.preventDefault()
         return
       return if @pasting
-      Mercury.changes = true
+      Mercury.trigger('set-changes', true)
       @handlePaste(event.originalEvent)
 
     @element.on 'focus', =>
@@ -189,7 +189,7 @@ class @Mercury.Regions.Editable extends Mercury.Region
     @element.on 'keyup', =>
       return if @previewing
       Mercury.trigger('region:update', {region: @})
-      Mercury.changes = true
+      Mercury.trigger('set-changes', true)
 
 
   focus: ->

--- a/vendor/assets/javascripts/mercury/regions/markupable.js.coffee
+++ b/vendor/assets/javascripts/mercury/regions/markupable.js.coffee
@@ -129,7 +129,7 @@ class @Mercury.Regions.Markupable extends Mercury.Region
 
     @element.on 'keyup', =>
       return if @previewing
-      Mercury.changes = true
+      Mercury.trigger('set-changes', true)
       @resize()
       Mercury.trigger('region:update', {region: @})
 

--- a/vendor/assets/javascripts/mercury/regions/simple.js.coffee
+++ b/vendor/assets/javascripts/mercury/regions/simple.js.coffee
@@ -135,7 +135,7 @@ class @Mercury.Regions.Simple extends Mercury.Region
 
     @element.on 'keyup', =>
       return if @previewing
-      Mercury.changes = true
+      Mercury.trigger('set-changes', true)
       @resize()
       Mercury.trigger('region:update', {region: @})
 
@@ -150,7 +150,7 @@ class @Mercury.Regions.Simple extends Mercury.Region
         event.preventDefault()
         return
       return if @pasting
-      Mercury.changes = true
+      Mercury.trigger('set-changes', true)
       @handlePaste(event.originalEvent)
 
 

--- a/vendor/assets/javascripts/mercury/regions/snippetable.js.coffee
+++ b/vendor/assets/javascripts/mercury/regions/snippetable.js.coffee
@@ -57,7 +57,7 @@ class @Mercury.Regions.Snippetable extends Mercury.Region
 
     jQuery(@document).on 'keyup', =>
       return if @previewing || Mercury.region != @
-      Mercury.changes = true
+      Mercury.trigger('set-changes', true)
 
 
   focus: ->


### PR DESCRIPTION
Re: https://github.com/jejacks0n/mercury/issues/190#issuecomment-4663955
- Generates `toggle:preview` mode event when entering/leaving preview mode.
- Uses `set-changes` event rather than directly setting Mercury.changes
- Triggers `changes` event whenever changes state toggles

For preview only, no specs yet. Bundle is hanging and I cannot run existing specs. Hoping master is clean.
