### PR TITLE
Allow for a lazy evaluated url functions for Dialog inheriting classes

### DIFF
--- a/vendor/assets/javascripts/mercury/dialog.js.coffee
+++ b/vendor/assets/javascripts/mercury/dialog.js.coffee
@@ -7,7 +7,7 @@ class @Mercury.Dialog
 
   # The constructor expects a url to load, a name, and options.
   #
-  # @url _string_ used to load the contents, either using Ajax or by pulling content from preloadedViews
+  # @url _string_ or _function_ used to load the contents, either using Ajax or by pulling content from preloadedViews
   #
   # @name _string_ used in building of the element, and is assigned as part of the elements class (eg.
   #     `mercury-[name]-dialog`)
@@ -125,16 +125,18 @@ class @Mercury.Dialog
   # @callback _function_ will be called after the content is loaded.
   load: (callback) ->
     return unless @url
-    if Mercury.preloadedViews[@url]
+    url = if jQuery.isFunction(@url) then @url.call(@, @name) else @url
+
+    if Mercury.preloadedViews[url]
       # If there's a preloadedView defined for the url being requested, load that one.
-      @loadContent(Mercury.preloadedViews[@url])
+      @loadContent(Mercury.preloadedViews[url])
       # And call the dialog handler if there's one.  We've broken the handlers out into separate files so they can be
       # tested more easily, but you can define your own by putting them in dialogHandlers.
       Mercury.dialogHandlers[@name].call(@) if Mercury.dialogHandlers[@name]
       callback() if callback
     else
       # Otherwise make an Ajax request to get the content.
-      jQuery.ajax @url, {
+      jQuery.ajax url, {
         success: (data) =>
           @loadContent(data)
           Mercury.dialogHandlers[@name].call(@) if Mercury.dialogHandlers[@name]
@@ -143,7 +145,7 @@ class @Mercury.Dialog
           # If the Ajax fails, we hide the dialog and alert the user about the error.
           @hide()
           @button.removeClass('pressed') if @button
-          Mercury.notify('Mercury was unable to load %s for the "%s" dialog.', @url, @name)
+          Mercury.notify('Mercury was unable to load %s for the "%s" dialog.', url, @name)
       }
 
 

--- a/vendor/assets/javascripts/mercury/toolbar.button.js.coffee
+++ b/vendor/assets/javascripts/mercury/toolbar.button.js.coffee
@@ -34,19 +34,16 @@ class @Mercury.Toolbar.Button
 
         when 'palette'
           @element.addClass("mercury-button-palette")
-          url = if jQuery.isFunction(mixed) then mixed.call(@, @name) else mixed
-          @handled[type] = new Mercury.Palette(url, @name, @defaultDialogOptions())
+          @handled[type] = new Mercury.Palette(mixed, @name, @defaultDialogOptions())
 
         when 'select'
           @element.addClass("mercury-button-select").find('em').html(@title)
-          url = if jQuery.isFunction(mixed) then mixed.call(@, @name) else mixed
-          @handled[type] = new Mercury.Select(url, @name, @defaultDialogOptions())
+          @handled[type] = new Mercury.Select(mixed, @name, @defaultDialogOptions())
 
         when 'panel'
           @element.addClass('mercury-button-panel')
-          url = if jQuery.isFunction(mixed) then mixed.call(@, @name) else mixed
           @handled['toggle'] = true
-          @handled[type] = new Mercury.Panel(url, @name, @defaultDialogOptions())
+          @handled[type] = new Mercury.Panel(mixed, @name, @defaultDialogOptions())
 
         when 'modal'
           @handled[type] = if jQuery.isFunction(mixed) then mixed.call(@, @name) else mixed


### PR DESCRIPTION
Currently toolbar buttons are initialized upon interface creation, and functions are evaluated then to get url content.
This is problematic for several reasons 
- You cannot implement any form of dynamic url return, once you generate url - that's final.
- You cannot use data from pageEditor.

Basic use case is to generate url for "historyPanel" based on source of irfame.

in layouts/mercury

``` javascript
pageEditor = new PageEditor(saveURL, options);
```

In morecury.js onload, or mercury_overrides.js

``` javascript
    Mercury.config.toolbars.primary.historyPanel[2].panel = function() {
      return pageEditor.iframeSrc() + "/versions";
    };
```

This will load a /versions for edited iframe, even if address changes during editing, or initial get is redirected.

This change adds dynamic url generation for all classes based on `Mercury.Dialog` it might be usefull to add that behaviour to other Buttons. Please let me know if you'd like me to do that.
