### PR TITLE
Drop rails dependency, depend on railties only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'http://rubygems.org'
 #Dependencies for the dummy app
 gem 'jquery-rails'
 gem 'sqlite3'
+gem 'activerecord'
+gem 'actionmailer'
 
 
 # Gems used only for assets and not required

--- a/mercury-rails.gemspec
+++ b/mercury-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
 
   # Runtime Dependencies
-  s.add_dependency 'rails', '~> 3.2'
+  s.add_dependency 'railties', '~> 3.2'
   s.add_dependency 'coffee-rails'
 
   # Development Dependencies

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,6 +1,9 @@
 require File.expand_path('../boot', __FILE__)
 
-require 'rails/all'
+require 'action_controller/railtie'
+require 'active_record/railtie'
+require 'action_mailer/railtie'
+require 'sprockets/railtie'
 
 Bundler.require
 require "mercury-rails"


### PR DESCRIPTION
...that way applications that don't need ActiveRecord do not get it from an editor engine.

I use CouchDB in an app and would like to avoid the overhead of loading AR just because Mercury depends on rails. In my eyes, it's enough to depend on railties.

I'd love to get feedback on this—the tests were okay after cloning, but I now get:

```
And the selected cell should be the forth cell in the second row                                                                                                                                                                                                                                                                                                                                    # features/step_definitions/mercury_steps.rb:193
  Unable to locate the selected cell for '.mercury-modal tr:nth-child(2n) td.selected:nth-child(4n)' (Capybara::ElementNotFound)
  (eval):2:in `find'
  ./features/step_definitions/mercury_steps.rb:195:in `/^the selected cell should be (.*?)$/'
  features/regions/full/inserting_tables.feature:37:in `And the selected cell should be the forth cell in the second row'
```

I'm not sure but I don't see how that could relate to my change.

If you have any more questions, please let me know.
