### PR TITLE
Allow inserted tables to inherit border and cellspacing properties

### DIFF
--- a/app/assets/javascripts/mercury/modals/inserttable.js.coffee
+++ b/app/assets/javascripts/mercury/modals/inserttable.js.coffee
@@ -41,13 +41,19 @@
   setTableAlignment: ->
     @table.attr({align: @element.find('#table_alignment').val()})
 
-
   setTableBorder: ->
-    @table.attr({border: parseInt(@element.find('#table_border').val(), 10) || 1})
-
+    border = parseInt(@element.find('#table_border').val(), 10)
+    if isNaN(border)
+      @table.removeAttr('border')
+    else
+      @table.attr({border: border})
 
   setTableCellSpacing: ->
-    @table.attr({cellspacing: parseInt(@element.find('#table_spacing').val(), 10) || 1})
+    cellspacing = parseInt(@element.find('#table_spacing').val(), 10)
+    if isNaN(cellspacing)
+      @table.removeAttr('cellspacing')
+    else
+      @table.attr({cellspacing: cellspacing})
 
 
   submitForm: ->

--- a/spec/javascripts/mercury/modals/inserttable_spec.js.coffee
+++ b/spec/javascripts/mercury/modals/inserttable_spec.js.coffee
@@ -118,6 +118,11 @@ describe "Mercury.modalHandlers.insertTable", ->
       jasmine.simulate.keyup($('#table_border').get(0))
       expect($('table').attr('border')).toEqual('2')
 
+    it "removes the property if empty value specified", ->
+      $('#table_border').val('')
+      jasmine.simulate.keyup($('#table_border').get(0))
+      expect($('table').attr('border')).toEqual(undefined)
+
 
   describe "changing the cellspacing", ->
 
@@ -133,6 +138,11 @@ describe "Mercury.modalHandlers.insertTable", ->
       $('#table_spacing').val('12x')
       jasmine.simulate.keyup($('#table_spacing').get(0))
       expect($('table').attr('cellspacing')).toEqual('12')
+
+    it "removes the property if empty value specified", ->
+      $('#table_spacing').val('')
+      jasmine.simulate.keyup($('#table_spacing').get(0))
+      expect($('table').attr('cellspacing')).toEqual(undefined)
 
 
   describe "submitting", ->


### PR DESCRIPTION
I was plagued by being unable to enter "0" for the border property... 

At inserttable.js.coffee:45, the code was inserting  `<inputted value> || 1` for the new border attribute value.  This results in 1 if 0 is entered.  I believe it should be possible to enter 0 for these values.

I then reasoned that in addition to zero, no-value should result in the property being removed so that a table can receive border and cellspacing properties from stylesheets or parent elements.
