### PR TITLE
Accept --haml option for mercury:install generator

### DIFF
--- a/app/views/layouts/mercury.html.haml
+++ b/app/views/layouts/mercury.html.haml
@@ -1,0 +1,19 @@
+!!!
+%html
+  %head
+    %meta{:name => "viewport", :content => "width=device-width, maximum-scale=1.0, initial-scale=1.0"}
+    = csrf_meta_tags
+    %title Mercury Editor
+    = stylesheet_link_tag    'mercury'
+    = javascript_include_tag 'jquery-1.7', 'mercury'
+  %body
+    :javascript
+      // Set to the url that you want to save any given page to, leave null for default handling.
+      var saveUrl = null;
+
+      // Instantiate the PageEditor
+      new Mercury.PageEditor(saveUrl, {
+        saveStyle:  null, // 'form', or 'json' (default json)
+        saveMethod: null, // 'PUT', or 'POST', (create, vs. update -- default PUT)
+        visible:    true  // boolean - if the interface should start visible or not
+      });

--- a/lib/generators/mercury/install/install_generator.rb
+++ b/lib/generators/mercury/install/install_generator.rb
@@ -8,6 +8,9 @@ module Mercury
       class_option :full, :type => :boolean, :aliases => '-g',
                    :desc => 'Full installation will install the layout and css files for easier customization.'
 
+      class_option :haml, :type => :boolean,
+                   :desc => 'Use a Haml layout template (instead of ERB)'
+
       def copy_config
         copy_file 'app/assets/javascripts/mercury.js'
       end
@@ -18,7 +21,8 @@ module Mercury
 
       def copy_layout_and_css_overrides
         if options[:full] || yes?("Install the layout file and CSS? [yN]")
-          copy_file 'app/views/layouts/mercury.html.erb'
+          layout_ext = (options[:haml]) ? 'haml' : 'erb'
+          copy_file "app/views/layouts/mercury.html.#{layout_ext}"
           copy_file 'app/assets/stylesheets/mercury.css'
         end
       end


### PR DESCRIPTION
When `--haml` is passed as an option to `rails generate mercury:install`, a Haml version of the Mercury layout is copied to the project (instead of the default ERB layout).

Awesome project, BTW!  Let me know if there's anything I can do to improve this pull request.
