### PR TITLE
Fix double script execution

### DIFF
--- a/app/assets/javascripts/mercury/region.js.coffee
+++ b/app/assets/javascripts/mercury/region.js.coffee
@@ -48,8 +48,10 @@ class @Mercury.Region
       @element.html(value)
     else
       # sanitize the html before we return it
-      container = jQuery('<div>').appendTo(@document.createDocumentFragment())
-      container.html(@element.html().replace(/^\s+|\s+$/g, ''))
+      # create the element without jQuery since $el.html() executes <script> tags
+      container = document.createElement('div')
+      container.innerHTML = @element.html().replace(/^\s+|\s+$/g, '')
+      container = $(container)
 
       # replace snippet contents to be an identifier
       if filterSnippets then for snippet in container.find('[data-snippet]')

--- a/spec/javascripts/fixtures/mercury/region.html
+++ b/spec/javascripts/fixtures/mercury/region.html
@@ -1,2 +1,6 @@
 <div id="region" data-scope="scope" data-version="1">contents</div>
 <div id="region_with_snippet">contents<div class="example-snippet" data-snippet="snippet_1" data-version="1">snippet</div></div>
+<div id="region_with_javascript_snippet"><div class="example-snippet" data-snippet="snippet_1" data-version="1">
+  <ul id="modifyable-element"></ul>
+  <script>$("#modifyable-element").append("<li />");</script>
+</div></div>

--- a/spec/javascripts/mercury/region_spec.js.coffee
+++ b/spec/javascripts/mercury/region_spec.js.coffee
@@ -156,7 +156,7 @@ describe "Mercury.Region", ->
         expect(@triggerSpy.argsForCall[0]).toEqual(['hide:toolbar', {type: 'snippet', immediately: false}])
 
 
-  describe "#html", ->
+  describe "#content", ->
 
     beforeEach ->
       @region = new Mercury.Region($('#region_with_snippet'), window)
@@ -170,6 +170,10 @@ describe "Mercury.Region", ->
       it "replaces snippet content with an indentifier if asked", ->
         content = @region.content(null, true)
         expect(content).toEqual('contents<div class="example-snippet" data-snippet="snippet_1">[snippet_1]</div>')
+
+      it "does not execute JavaScript contained within the region (bug fix)", ->
+        (new Mercury.Region($('#region_with_javascript_snippet'), window)).content()
+        expect($('#modifyable-element').children().length).toEqual(0)
 
     describe "setting html", ->
 


### PR DESCRIPTION
If I have a snippet which contains some JavaScript, the JavaScript will be executed twice upon page load. In my situation, this causes bugs because code is being executed against the same DOM multiple times.

The JavaScript must be in the snippet markup so that when the snippet is injected/reinjected, the JavaScript is executed. I'm not aware of any Mercury hooks for when a snippet is reinjected.

Eg:

**Snippet HTML**

``` html
<ul class="my-ul"></ul>

<script>
  $('.my-ul').append($('<li>test</li>'));
</script>
```

Upon page load, the result of the snippet's UL will be:

``` html
<ul class="my-ul">
  <li>test</li>
  <li>test</li>
</ul>
```

The results should be:

``` html
<ul class="my-ul">
  <li>test</li>
</ul>
```

This change uses raw JS to capture the adjusted HTML and create a jQuery element for it. jQuery's `$('<div />').html('<script>alert("yo");</script>')` will execute the script immediately, even if it's not injected into the DOM, so this technique is avoided.

I thought through some alternative solutions that didn't require modifying Mercury but came up short. Unique IDs, data-loaded attributes, singleton objects, or moving JS outside the snippet were amongst them.
