### PR TITLE
prevent infinite-loops when loading mercury editor

### DIFF
--- a/app/assets/javascripts/mercury/page_editor.js.coffee
+++ b/app/assets/javascripts/mercury/page_editor.js.coffee
@@ -177,8 +177,7 @@ class @Mercury.PageEditor
   iframeSrc: (url = null, params = false) ->
     # remove the /editor segment of the url if it gets passed through
     url = (url ? window.location.href).replace(Mercury.config.editorUrlRegEx ?= /([http|https]:\/\/.[^\/]*)\/editor\/?(.*)/i,  "$1/$2")
-    url = url.replace(/[\?|\&]mercury_frame=true/gi, '')
-    url = url.replace(/\&_=\d+/gi, '')
+    url = url.replace(/[\?|\&]mercury_frame=true/gi, '').replace(/\&_=\d+/gi, '').replace(/#$/, '')
     if params
       # add a param allowing the server to know that the request is coming from mercury
       # and add a cache busting param so we don't get stale content


### PR DESCRIPTION
When I followed "Rails Integration Techniques", there is a problem with loading Mercury editor.

When the page is ended with #, Mercury editor will be loaded even in the iframe, which creates an infinite-loops of loading the editor.

This happened because param mercury_frame was not set, due to being after the hash "#" symbol.

The pull request just adds a replace call to remove the trailing hash in iframeSrc url.
