### PR TITLE
Fixed inserting Snippet in Chrome bug (issue #362)

### DIFF
--- a/app/assets/javascripts/mercury/regions/full.js.coffee
+++ b/app/assets/javascripts/mercury/regions/full.js.coffee
@@ -68,9 +68,10 @@ class @Mercury.Regions.Full extends Mercury.Region
       return if @previewing
       event.preventDefault() unless Mercury.snippet
       event.originalEvent.dataTransfer.dropEffect = 'copy'
-      if jQuery.browser.webkit
-        clearTimeout(@dropTimeout)
-        @dropTimeout = setTimeout((=> @element.trigger('possible:drop')), 10)
+      # removed to fix chrome update issue #362 https://github.com/jejacks0n/mercury/issues/362
+      # if jQuery.browser.webkit
+        # clearTimeout(@dropTimeout)
+        # @dropTimeout = setTimeout((=> @element.trigger('possible:drop')), 10)
 
     @element.on 'drop', (event) =>
       return if @previewing
@@ -92,9 +93,9 @@ class @Mercury.Regions.Full extends Mercury.Region
     # read: http://www.quirksmode.org/blog/archives/2009/09/the_html5_drag.html
     @element.on 'possible:drop', =>
       return if @previewing
-      if snippetPlaceHolder = @element.find('img[data-snippet]').get(0)
+      if Mercury.snippet
         @focus()
-        Mercury.Snippet.displayOptionsFor(jQuery(snippetPlaceHolder).data('snippet'), {}, jQuery(snippetPlaceHolder).data('options'))
+        Mercury.Snippet.displayOptionsFor(Mercury.snippet.name, {}, Mercury.snippet.hasOptions)
         @document.execCommand('undo', false, null)
 
     # custom paste handling: we have to do some hackery to get the pasted content since it's not exposed normally


### PR DESCRIPTION
Updated source for "full" region so dropping a Snippet works again with the latest Chrome
