### PR TITLE
Converts match routes to get routes for Rails 4.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Mercury::Engine.routes.draw do
-  match '/editor(/*requested_uri)' => "mercury#edit", :as => :mercury_editor
+  get '/editor(/*requested_uri)' => "mercury#edit", :as => :mercury_editor
 
   scope '/mercury' do
-    match ':type/:resource' => "mercury#resource"
-    match 'snippets/:name/options' => "mercury#snippet_options"
-    match 'snippets/:name/preview' => "mercury#snippet_preview"
+    get ':type/:resource' => "mercury#resource"
+    get 'snippets/:name/options' => "mercury#snippet_options"
+    get 'snippets/:name/preview' => "mercury#snippet_preview"
   end
 end


### PR DESCRIPTION
Implements issue #333 (https://github.com/jejacks0n/mercury/issues/333)
