### PR TITLE
Change dependencies to be rails4 compatible

### DIFF
--- a/mercury-rails.gemspec
+++ b/mercury-rails.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.licenses    = ['MIT']
 
   # Runtime Dependencies
-  s.add_dependency 'railties', '~> 3.2'
-  s.add_dependency 'coffee-rails', '~> 3.2.2'
+  s.add_dependency 'railties', '>= 3.2'
+  s.add_dependency 'coffee-rails', '>= 3.2.2'
 
   # Gem Files
   s.extra_rdoc_files  = %w(LICENSE POST_INSTALL)


### PR DESCRIPTION
I have this branch working within a Rails4 (beta1) app. This change allows to use rails4 with mercury.
