### PR TITLE
support POST verb on snippet routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Mercury::Engine.routes.draw do
   get '/editor(/*requested_uri)' => "mercury#edit", :as => :mercury_editor
 
   scope '/mercury' do
-    get ':type/:resource' => "mercury#resource"
-    get 'snippets/:name/options' => "mercury#snippet_options"
-    get 'snippets/:name/preview' => "mercury#snippet_preview"
+    get   ':type/:resource',        :to => "mercury#resource"
+    match 'snippets/:name/options', :to => "mercury#snippet_options", :via => [:get, :post]
+    match 'snippets/:name/preview', :to => "mercury#snippet_preview", :via => [:get, :post]
   end
 end


### PR DESCRIPTION
appears that snippet insertion was broken by commit d3b085e. This patch fixes the problem by allowing the POST verb on snippet routes.
