### PR TITLE
fix dummy app to run locally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :assets do
   gem 'sass-rails'
   gem 'uglifier'
   gem 'sprockets-rails'
+  gem 'therubyracer', platforms: :ruby
 end
 
 group :development, :test do

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  match 'mercury/test_page' => "mercury#test_page"
+  get 'mercury/test_page' => "mercury#test_page"
 
   mount Mercury::Engine => "/"
 end


### PR DESCRIPTION
Fix some problems with the dummy app. Currently when you try to run the dummy rails app failed because sprockets needs a Javascript runtime, after that the routes file use a pretty old match syntax.
