### PR TITLE
Сompatibility with paperclip 4.x version

### DIFF
--- a/lib/generators/mercury/install/images/templates/ar_paperclip_image.rb.erb
+++ b/lib/generators/mercury/install/images/templates/ar_paperclip_image.rb.erb
@@ -9,6 +9,8 @@ class Mercury::Image < ActiveRecord::Base
         :path => ":rails_root/public/system/:attachment/:id/:style/:filename",
         :url => "/system/:attachment/:id/:style/:filename"
 
+  validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
+
   delegate :url, :to => :image
 
   def serializable_hash(options = nil)

--- a/lib/generators/mercury/install/images/templates/mongoid_paperclip_image.rb
+++ b/lib/generators/mercury/install/images/templates/mongoid_paperclip_image.rb
@@ -3,8 +3,10 @@ class Mercury::Image
   include Mongoid::Paperclip
 
   has_mongoid_attached_file :image
+  validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
 
   validates_presence_of :image
+
 
   delegate :url, :to => :image
 


### PR DESCRIPTION
Since version 4 should be added to the model the following code

``` ruby
validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
```

I have added it to mdel's templates
