### PR TITLE
Fix the issue with Right Alt+S on polish keyboard layout

### DIFF
--- a/app/assets/javascripts/mercury/page_editor.js.coffee
+++ b/app/assets/javascripts/mercury/page_editor.js.coffee
@@ -110,7 +110,7 @@ class @Mercury.PageEditor
         Mercury.trigger('unfocus:regions') unless jQuery(event.target).closest("[#{Mercury.config.regions.attribute}]").get(0) == Mercury.region.element.get(0)
 
     jQuery(@document).bind 'keydown', (event) =>
-      return unless event.ctrlKey || event.metaKey
+      return unless (event.ctrlKey && !event.altKey) || event.metaKey
       if (event.keyCode == 83) # meta+S
         Mercury.trigger('action', {action: 'save'})
         event.preventDefault()


### PR DESCRIPTION
Due to windows internally mapping right alt to ctrl+alt entering letter `ś` was impossible. This fix makes sure that save occurs only when ctrl+s is pressed (without alt).

For further informations see https://medium.com/medium-eng/the-curious-case-of-disappearing-polish-s-fa398313d4df#.cly480xc9